### PR TITLE
chore: Cherry-picked changes from upstream

### DIFF
--- a/.stepsecurity/maintenance.json
+++ b/.stepsecurity/maintenance.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 1,
+  "mode": "derivative",
+  "upstream": "chetan/git-restore-mtime-action",
+  "release_version_type": "vx.x.x",
+  "action_type": "composite",
+  "vendor_series_version": "2026.06.1",
+  "last_success": {
+    "upstream_tag": "v2.3",
+    "imported_at": "2026-07-27T07:29:25.715Z"
+  },
+  "last_attempt": {
+    "upstream_tag": "v2.3",
+    "status": "success",
+    "reason": "ok",
+    "at": "2026-07-27T07:29:25.715Z"
+  },
+  "tier": "A",
+  "policy": {
+    "stepwise_imports": true,
+    "skip_dist_from_upstream": true
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-[![StepSecurity Maintained Action](https://raw.githubusercontent.com/step-security/maintained-actions-assets/main/assets/maintained-action-banner.png)](https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions)
-
 # git-restore-mtime action
 
-A GitHub Workflow Action which restores timestamps of files in the current tree based on their last commit times. Uses the [git-restore-mtime](https://github.com/MestreLion/git-tools) script.
+[![StepSecurity Maintained Action](https://raw.githubusercontent.com/step-security/maintained-actions-assets/main/assets/maintained-action-banner.png)](https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions)
+
+A GitHub Workflow Action which restores timestamps of files in the current tree based on their last commit times. Uses the [git-restore-mtime](https://github.com/MestreLion/git-tools) script (v2025.08 release) by [@MestreLion](https://github.com/MestreLion).
 
 ## Usage
 
@@ -20,7 +20,7 @@ name: Build and Deploy
 on:
   push:
     branches:
-      - main
+      - master
 
 jobs:
   build-and-deploy:
@@ -60,9 +60,9 @@ jobs:
         # creates a shallow checkout.
         fetch-depth: 0
 
-      # Fix timestamps
-      - name: restore timestamps
-        uses: step-security/git-restore-mtime-action@v2
+    # Fix timestamps
+    - name: restore timestamps
+      uses: step-security/git-restore-mtime-action@v2
 
     # Upload to S3
     - name: sync s3
@@ -86,4 +86,42 @@ jobs:
     # Directory to change to before running the action. (Optional)
     # Default: '.'
     working-directory: '.'
+    # Extra arguments to pass to git-restore-mtime script. (Optional)
+    # Default: ''
+    args: --unique-times
 ```
+
+#### Available flags
+
+```
+usage: git-restore-mtime [-h] [--quiet | --verbose] [--cwd DIRECTORY] [--git-dir GITDIR] [--work-tree WORKTREE] [--force] [--merge] [--first-parent] [--skip-missing] [--no-directories] [--test] [--commit-time]
+                         [--oldest-time] [--skip-older-than SECONDS] [--skip-older-than-commit] [--unique-times] [--version]
+                         [PATHSPEC ...]
+
+Change the modification time (mtime) of files in work tree, based on the date of the most recent commit that modified the file, including renames. Ignores untracked files and uncommitted deletions, additions and
+renames, and by default modifications too.
+
+positional arguments:
+  PATHSPEC              Only modify paths matching PATHSPEC, relative to current directory. By default, update all but untracked files and submodules.
+```
+
+| Option | Description |
+|--------|-------------|
+| `-h`, `--help` | show this help message and exit |
+| `--quiet`, `-q` | Suppress informative messages and summary statistics. |
+| `--verbose`, `-v` | Print additional information for each processed file. Specify twice to further increase verbosity. |
+| `--cwd`, `-C DIRECTORY` | Run as if git-restore-mtime was started in directory DIRECTORY. This affects how --work-tree, --git-dir and PATHSPEC arguments are handled. See 'man 1 git' or 'git --help' for more information. |
+| `--git-dir GITDIR` | Path to the git repository, by default auto-discovered by searching the current directory and its parents for a .git/ subdirectory. |
+| `--work-tree WORKTREE` | Path to the work tree root, by default the parent of GITDIR if it's automatically discovered, or the current directory if GITDIR is set. |
+| `--force`, `-f` | Force updating files with uncommitted modifications. Untracked files and uncommitted deletions, renames and additions are always ignored. |
+| `--merge`, `-m` | Include merge commits. Leads to more recent times and more files per commit, thus with the same time, which may or may not be what you want. Including merge commits may lead to fewer commits being evaluated as files are found sooner, which can improve performance, sometimes substantially. But as merge commits are usually huge, processing them may also take longer. By default, merge commits are only used for files missing from regular commits. |
+| `--first-parent` | Consider only the first parent, the "main branch", when evaluating merge commits. Only effective when merge commits are processed, either when --merge is used or when finding missing files after the first regular log search. See --skip-missing. |
+| `--skip-missing`, `-s` | Do not try to find missing files. If merge commits were not evaluated with --merge and some files were not found in regular commits, by default git-restore-mtime searches for these files again in the merge commits. This option disables this retry, so files found only in merge commits will not have their timestamp updated. |
+| `--no-directories`, `-D` | Do not update directory timestamps. By default, use the time of its most recently created, renamed or deleted file. Note that just modifying a file will NOT update its directory time. |
+| `--test`, `-t` | Test run: do not actually update any file timestamp. |
+| `--commit-time`, `-c` | Use commit time instead of author time. |
+| `--oldest-time`, `-o` | Update times based on the oldest, instead of the most recent commit of a file. This reverses the order in which the git log is processed to emulate a file "creation" date. Note this will be inaccurate for files deleted and re-created at later dates. |
+| `--skip-older-than SECONDS` | Ignore files that are currently older than SECONDS. Useful in workflows that assume such files already have a correct timestamp, as it may improve performance by processing fewer files. |
+| `--skip-older-than-commit`, `-N` | Ignore files older than the timestamp it would be updated to. Such files may be considered "original", likely in the author's repository. |
+| `--unique-times` | Set the microseconds to a unique value per commit. Allows telling apart changes that would otherwise have identical timestamps, as git's time accuracy is in seconds. |
+| `--version`, `-V` | show program's version number and exit |

--- a/action.yml
+++ b/action.yml
@@ -1,61 +1,67 @@
 name: 'git-restore-mtime'
 description: "Restore file's modified time (timestamp) based on git commits"
+author: step-security
 inputs:
   working-directory:
     description: "Where to run the action"
     required: false
     default: '.'
+  args:
+    description: "Command line arguments to pass to git-restore-mtime"
+    required: false
+    default: ''
 branding:
   icon: 'clock'
   color: 'orange'
 runs:
   using: "composite"
   steps:
-    - name: Subscription check
-      env:
-        REPO_PRIVATE: ${{ github.event.repository.private }}
+- name: Subscription check
+  # stepsecurity:subscription:start
+  env:
+    REPO_PRIVATE: ${{ github.event.repository.private }}
+  run: |
+    # validate subscription status
+    UPSTREAM="chetan/git-restore-mtime-action"
+    ACTION_REPO="${GITHUB_ACTION_REPOSITORY:-}"
+    DOCS_URL="https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions"
+
+    echo ""
+    echo -e "\033[1;36mStepSecurity Maintained Action\033[0m"
+    echo "Secure drop-in replacement for $UPSTREAM"
+    if [ "$REPO_PRIVATE" = "false" ]; then
+      echo -e "\033[32m✓ Free for public repositories\033[0m"
+    fi
+    echo -e "\033[36mLearn more:\033[0m $DOCS_URL"
+    echo ""
+
+    if [ "$REPO_PRIVATE" != "false" ]; then
+      SERVER_URL="${GITHUB_SERVER_URL:-https://github.com}"
+
+      if [ "$SERVER_URL" != "https://github.com" ]; then
+        BODY=$(printf '{"action":"%s","ghes_server":"%s"}' "$ACTION_REPO" "$SERVER_URL")
+      else
+        BODY=$(printf '{"action":"%s"}' "$ACTION_REPO")
+      fi
+
+      API_URL="https://agent.api.stepsecurity.io/v1/github/$GITHUB_REPOSITORY/actions/maintained-actions-subscription"
+
+      RESPONSE=$(curl --max-time 3 -s -w "%{http_code}" \
+        -X POST \
+        -H "Content-Type: application/json" \
+        -d "$BODY" \
+        "$API_URL" -o /dev/null) && CURL_EXIT_CODE=0 || CURL_EXIT_CODE=$?
+
+      if [ $CURL_EXIT_CODE -ne 0 ]; then
+        echo "Timeout or API not reachable. Continuing to next step."
+      elif [ "$RESPONSE" = "403" ]; then
+        echo -e "::error::\033[1;31mThis action requires a StepSecurity subscription for private repositories.\033[0m"
+        echo -e "::error::\033[31mLearn how to enable a subscription: $DOCS_URL\033[0m"
+        exit 1
+      fi
+    fi
+  # stepsecurity:subscription:end
+  shell: bash
+    - shell: bash
       run: |
-        UPSTREAM="chetan/git-restore-mtime-action"
-        ACTION_REPO="${GITHUB_ACTION_REPOSITORY:-}"
-        DOCS_URL="https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions"
-
-        echo ""
-        echo -e "\033[1;36mStepSecurity Maintained Action\033[0m"
-        echo "Secure drop-in replacement for $UPSTREAM"
-        if [ "$REPO_PRIVATE" = "false" ]; then
-          echo -e "\033[32m✓ Free for public repositories\033[0m"
-        fi
-        echo -e "\033[36mLearn more:\033[0m $DOCS_URL"
-        echo ""
-
-        if [ "$REPO_PRIVATE" != "false" ]; then
-          SERVER_URL="${GITHUB_SERVER_URL:-https://github.com}"
-
-          if [ "$SERVER_URL" != "https://github.com" ]; then
-            BODY=$(printf '{"action":"%s","ghes_server":"%s"}' "$ACTION_REPO" "$SERVER_URL")
-          else
-            BODY=$(printf '{"action":"%s"}' "$ACTION_REPO")
-          fi
-
-          API_URL="https://agent.api.stepsecurity.io/v1/github/$GITHUB_REPOSITORY/actions/maintained-actions-subscription"
-
-          RESPONSE=$(curl --max-time 3 -s -w "%{http_code}" \
-            -X POST \
-            -H "Content-Type: application/json" \
-            -d "$BODY" \
-            "$API_URL" -o /dev/null) && CURL_EXIT_CODE=0 || CURL_EXIT_CODE=$?
-
-          if [ $CURL_EXIT_CODE -ne 0 ]; then
-            echo "Timeout or API not reachable. Continuing to next step."
-          elif [ "$RESPONSE" = "403" ]; then
-            echo -e "::error::\033[1;31mThis action requires a StepSecurity subscription for private repositories.\033[0m"
-            echo -e "::error::\033[31mLearn how to enable a subscription: $DOCS_URL\033[0m"
-            exit 1
-          fi
-        fi
-      shell: bash
-
-    - name: Run git-restore-mtime
-      shell: bash
-      run: |
-        cd "${{ inputs.working-directory }}" && "$GITHUB_ACTION_PATH"/git-restore-mtime
+        cd "${{ inputs.working-directory }}" && "$GITHUB_ACTION_PATH"/git-restore-mtime ${{ inputs.args }}

--- a/git-restore-mtime
+++ b/git-restore-mtime
@@ -30,8 +30,7 @@ assuming the actual modification date and its commit date are close.
 """
 
 # TODO:
-# - Add -z on git whatchanged/ls-files, so we don't deal with filename decoding
-# - When Python is bumped to 3.7, use text instead of universal_newlines on subprocess
+# - Add -z on git log/ls-files, so we don't deal with filename decoding
 # - Update "Statistics for some large projects" with modern hardware and repositories.
 # - Create a README.md for git-restore-mtime alone. It deserves extensive documentation
 #   - Move Statistics there
@@ -76,10 +75,13 @@ import subprocess
 import sys
 import time
 
-__version__ = "2022.12"
+if sys.version_info < (3, 8):
+    sys.exit("Python 3.8 or later required.")
+
+__version__ = "2025.08"
 
 # Update symlinks only if the platform supports not following them
-UPDATE_SYMLINKS = bool(os.utime in getattr(os, 'supports_follow_symlinks', []))
+UPDATE_SYMLINKS = bool({os.utime, os.stat} <= getattr(os, 'supports_follow_symlinks', set()))
 
 # Call os.path.normpath() only if not in a POSIX platform (Windows)
 NORMALIZE_PATHS = (os.path.sep != '/')
@@ -241,8 +243,14 @@ def normalize(path):
     normalize(r'"Back\\slash_double\"quote_a\303\247a\303\255"') =>
         r'Back\slash_double"quote_açaí')
 
-    See notes on `windows/non-ascii-paths.txt` about path encodings on non-UTF-8
-    platforms and filesystems.
+    Paths with invalid UTF-8 encoding, such as single 0x80-0xFF bytes (e.g, from
+    Latin1/Windows-1251 encoding) are decoded using surrogate escape, the same
+    method used by Python for filesystem paths. So 0xE6 ("æ" in Latin1, r'\\346'
+    from Git) is decoded as "\udce6". See https://peps.python.org/pep-0383/ and
+    https://vstinner.github.io/painful-history-python-filesystem-encoding.html
+
+    Also see notes on `windows/non-ascii-paths.txt` about path encodings on
+    non-UTF-8 platforms and filesystems.
     """
     if path and path[0] == '"':
         # Python 2: path = path[1:-1].decode("string-escape")
@@ -250,8 +258,8 @@ def normalize(path):
         path = (path[1:-1]                 # Remove enclosing double quotes
                 .encode('latin1')          # Convert to bytes, required by 'unicode-escape'
                 .decode('unicode-escape')  # Perform the actual octal-escaping decode
-                .encode('latin1')          # 1:1 mapping to bytes, forming UTF-8 encoding
-                .decode('utf8'))           # Decode from UTF-8
+                .encode('latin1')          # 1:1 mapping to bytes, UTF-8 encoded
+                .decode('utf8', 'surrogateescape'))  # Decode from UTF-8
     if NORMALIZE_PATHS:
         # Make sure the slash matches the OS; for Windows we need a backslash
         path = os.path.normpath(path)
@@ -292,7 +300,7 @@ def get_mtime_ns(secs: int, idx: int):
 
 
 def get_mtime_path(path):
-    return os.path.getmtime(path)
+    return os.stat(path, **UTIME_KWS).st_mtime
 
 
 # Git class and parse_log(), the heart of the script ##########################
@@ -318,8 +326,8 @@ class Git:
 
     def log(self, merge=False, first_parent=False, commit_time=False,
             reverse_order=False, paths: list = None):
-        cmd = 'log --raw --pretty={}'.format('%ct' if commit_time else '%at')
-        if merge:         cmd += ' -m'
+        cmd = 'log --raw --no-show-signature --pretty={}'.format('%ct' if commit_time else '%at')
+        cmd += ' -m' if merge else ' --no-merges'
         if first_parent:  cmd += ' --first-parent'
         if reverse_order: cmd += ' --reverse'
         return self._run(cmd, paths)
@@ -345,7 +353,7 @@ class Git:
         if paths:
             cmdlist.append('--')
             cmdlist.extend(paths)
-        popen_args = dict(universal_newlines=True, encoding='utf8')
+        popen_args = dict(text=True, encoding='utf8')
         if not self.errors:
             popen_args['stderr'] = subprocess.DEVNULL
         log.trace("Executing: %s", ' '.join(cmdlist))


### PR DESCRIPTION
## 📦 Upstream import

- **Maintained Action:** `step-security/git-restore-mtime-action`
- **Upstream Action:** `chetan/git-restore-mtime-action`
- **Range:** `v2.1.1` → `v2.3`
- **Action type:** `composite`
- **Triage:** `auto-merge-candidate`
- **Build:** skipped (action type composite — no node build)

[Upstream compare](https://github.com/chetan/git-restore-mtime-action/compare/v2.1.1...v2.3)

### Applied from upstream (3)
- `README.md`
- `action.yml`
- `git-restore-mtime`

### StepSecurity changes
- **subscription:** ok action.yml
- **ci-workflows:** ok
  - `.github/workflows/tests.yml`: no changes needed
